### PR TITLE
Fix issues with padding and null bytes

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -2,10 +2,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main (main) where
 
-import           ClockworkBase32 (decode, decodeString, encode, encodeString)
-import qualified Data.ByteString as BS
-import           Data.List (isInfixOf)
-import           Test.Hspec
+import ClockworkBase32 (decode, decodeString, encode, encodeString)
+import Data.List (isInfixOf)
+import Test.Hspec
 
 main :: IO ()
 main = hspec $ do


### PR DESCRIPTION
Hey, not sure if this is how you'd do this but I needed a fix for myself.

Cheers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter Base32 decoding: validates padding bits per spec and rejects non-zero padding; improves error propagation for malformed input.

* **Tests**
  * Expanded coverage: rejects invalid characters, treats alternate padding variants per spec, verifies padding-aware round-trip cases (including data with embedded NUL/zero bytes) and additional decode/encode round-trip scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->